### PR TITLE
Fix reverse migration for artist-user foreign key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Fix broken isolation of nox session when installing via Poetry ([#42](../../pull/42))
+- Fix reverse migration for artist-user foreign key ([#45](../../pull/45))
 
 ## [0.6.0] - 2019-08-29
 ### Added

--- a/migrations/versions/97089ffc8c1f_artists_belong_to_users.py
+++ b/migrations/versions/97089ffc8c1f_artists_belong_to_users.py
@@ -13,10 +13,10 @@ depends_on = None
 def upgrade():
     op.add_column("artists", sa.Column("user_id", sa.Integer(), nullable=True))
 
-    op.create_foreign_key(None, "artists", "users", ["user_id"], ["id"])
+    op.create_foreign_key("fk_user_id", "artists", "users", ["user_id"], ["id"])
 
 
 def downgrade():
-    op.drop_constraint(None, "artists", type_="foreignkey")
+    op.drop_constraint("fk_user_id", "artists", type_="foreignkey")
 
     op.drop_column("artists", "user_id")


### PR DESCRIPTION
Fix a bug where the foreign-key constraint cannot be dropped because no name was provided.